### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -8,20 +8,20 @@
 
 RGB	KEYWORD1
 HSV	KEYWORD1
-Color KEYWORD1
-NeoPixel KEYWORD1
+Color	KEYWORD1
+NeoPixel	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-toRGB KEYWORD2
-toHSV KEYWORD2
-begin KEYWORD2
-setPixelColor KEYWORD2
-clear KEYWORD2
-update KEYWORD2
-getPixelColor KEYWORD2
-ColorTools KEYWORD2
+toRGB	KEYWORD2
+toHSV	KEYWORD2
+begin	KEYWORD2
+setPixelColor	KEYWORD2
+clear	KEYWORD2
+update	KEYWORD2
+getPixelColor	KEYWORD2
+ColorTools	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords